### PR TITLE
доп тест для количества изображений на странице оффера

### DIFF
--- a/cypress/fixtures/premium-offer.json
+++ b/cypress/fixtures/premium-offer.json
@@ -10,7 +10,8 @@
     "https://13.design.pages.academy/static/hotel/16.jpg",
     "https://13.design.pages.academy/static/hotel/4.jpg",
     "https://13.design.pages.academy/static/hotel/5.jpg",
-    "https://13.design.pages.academy/static/hotel/20.jpg"
+    "https://13.design.pages.academy/static/hotel/20.jpg",
+    "https://13.design.pages.academy/static/hotel/17.jpg"
   ],
   "city": {
     "name": "Paris",

--- a/cypress/integration/offer-page.feature
+++ b/cypress/integration/offer-page.feature
@@ -43,6 +43,7 @@ Feature: 1.1.2 Страница предложения
     Then элемент '.offer__image-wrapper:nth-child(4) .offer__image' содержит изображение 'https://13.design.pages.academy/static/hotel/4.jpg'
     Then элемент '.offer__image-wrapper:nth-child(5) .offer__image' содержит изображение 'https://13.design.pages.academy/static/hotel/5.jpg'
     Then элемент '.offer__image-wrapper:nth-child(6) .offer__image' содержит изображение 'https://13.design.pages.academy/static/hotel/20.jpg'
+    Then элемента '.offer__image-wrapper:nth-child(7) .offer__image' нет на странице
     Then элемент '.offer__name' содержит текст 'Offer #2'
     Then элемент '.offer__description' содержит текст 'Premium Paris offer description.'
     Then элемент '.offer__mark' видим


### PR DESCRIPTION
В тз есть пункт:
`На странице предложения (/offer) представлена расширенная информация об объекте для аренды: Фотографии. Выводится до 6-ти изображений.`

Сейчас это поведение не тестируется и как я понял сервер всегда возвращает 6 фото для каждого предложения, поэтому визуально сложно наткнуться на оффер где их больше и проверить факт ограничения количества. 
Добавил проверку для premium предложения на макс кол-во изображений